### PR TITLE
使用 Weibo API 获取用户 UID 和用户名

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -2,6 +2,7 @@
     'use strict';
     const $ = jQuery
 
+    let id
     let uid
     let username
 
@@ -23,71 +24,32 @@
     emojiMap.set('fetching', '🤯')
     emojiMap.set('done', '🤖')
 
-
-    // 获取要导出用户的UID
-    const getUID = async function () {
-        let uidFromURL = getUIDFromURL()
-        // let uidFromDom = getUIDFromDom()
-        return uidFromURL || ''
-    }
-
-    // 从URL里面获取
-    const getUIDFromURL = function () {
-        let uid
-        let url = location.href
-        let regRes = url.match(/weibo.com\/(u\/)?(\d+)/)
-        if (regRes && regRes.length > 1) {
-            uid = regRes.pop()
-        }
-        console.log('uid from url is: ', uid)
-        return uid
-    }
-
-    // 从Dom里面获取
-    const getUIDFromDom = function () {
-        let el = document.querySelector('header.woo-box-flex>a')
-
-        console.log(el)
-    }
-
-    const getUserNameFromTitle = function () {
-
-        let timer
-        let name
-        let count = 0
-        return new Promise((resolve, reject) => {
-            timer = setInterval(() => {
-                count++
-                let title = document.title
-                let nameReg = title.match(/@(\S+) 的个人主页/)
-                if (nameReg) {
-                    name = nameReg.pop()
-                    console.log(name)
-                    clearInterval(timer)
-                    resolve(name)
-                }
-                if (count > 5) resolve('')
-            }, 200);
+    // 使用 Weibo API 获取用户 UID 和用户名
+    const getInfo = function () {
+        id = getIDFromURL()
+        $.ajax({
+            async: false,
+            type: 'GET',
+            url: `https://weibo.com/ajax/profile/info?custom=${id}`,
+            success: function (data) {
+                uid = data.data.user.id
+                username = data.data.user.screen_name
+                console.log('uid', uid)
+                console.log('username', username)
+            }
         })
-
-    }
-    const getUserNameFromHTML = function(){
-        let nameEL = document.querySelector('h1.username')
-        let name
-        if(nameEL){
-            name = nameEL.textContent
-        }
-        else{
-            name = ''
-        }
-
-        return name
     }
 
-    const getUserName = async function(){
-        let nameFromHTML = getUserNameFromHTML()
-        let nameFromTitle = await getUserNameFromTitle()
-        return nameFromHTML || nameFromTitle
+    // 从URL中获取ID，注意不是UID
+    const getIDFromURL = function () {
+        let id
+        let url = location.href
+        let regRes = url.match(/weibo.com\/(u\/)*(\w+)/)
+        if (regRes && regRes.length > 1) {
+            id = regRes.pop()
+        }
+        console.log('id from url is: ', id)
+        return id
     }
     
     // 声明fetch方法
@@ -338,10 +300,8 @@
         fetchFinished()
     }
 
-    const init = async function(){
-        
-        uid = await getUID()
-        username = await getUserName();
+    const init = function(){
+        getInfo()
         initThePanel(uid)
     }
     init()

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -27,17 +27,20 @@
     // 使用 Weibo API 获取用户 UID 和用户名
     const getInfo = function () {
         id = getIDFromURL()
-        $.ajax({
-            async: false,
-            type: 'GET',
-            url: `https://weibo.com/ajax/profile/info?custom=${id}`,
-            success: function (data) {
-                uid = data.data.user.id
-                username = data.data.user.screen_name
-                console.log('uid', uid)
-                console.log('username', username)
-            }
-        })
+        if(id){
+            $.ajax({
+                async: false,
+                type: 'GET',
+                url: `https://weibo.com/ajax/profile/info?custom=${id}`,
+                success: function (data) {
+                    uid = data.data.user.id
+                    username = data.data.user.screen_name
+                    console.log('uid', uid)
+                    console.log('username', username)
+                }
+            })
+        }
+        
     }
 
     // 从URL中获取ID，注意不是UID
@@ -194,7 +197,7 @@
             })
         }
         else {
-            $speechlessMain.append(`😵‍💫 获取账号信息失败了...`)
+            $speechlessMain.append(`😵‍💫 请进入个人主页，刷新页面后使用`)
         }
     }
 


### PR DESCRIPTION
如果要导出的用户使用了自定义的 ID，如[@周楊HOPICO](https://weibo.com/cyoung1990)`https://weibo.com/cyoung1990`，使用 URL 匹配将无法获取正确的 UID，因此我试着使用`https://weibo.com/ajax/profile/info?custom=<id>`来一并获取用户名和 UID。这个 API 也同时支持使用数字 UID 或自定义 ID，对`weibo.com/u/<uid>`和`weibo.com/<id>`都能正常工作。

PS: 如果从 HTML DOM 获取 UID，在动态加载没有完成的情况下会无法正确获取